### PR TITLE
Add parallel execution support to Try.combine and Try.sequence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [2.0.0] - 2025-07-12
+### Modified
+- (BREAKING!) `sequence` will resolve all provided Try instances in parallel by default. It can be changed to be resolved sequentially by passing `false` as the second parameter
+- (BREAKING!) `combine` will resolve all provided Try instances in parallel by default. It can be changed to be resolved sequentially by passing `false` as the last parameter
+
 ## [1.5.0] - 2025-06-16
 ### Modified
 - `get`, `getOrElse`, `getOrElseGet`, `getOrElseThrow` will no longer rerun the entire steps chain and return the latest/cached result

--- a/jsr.json
+++ b/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@francois-egner/func-typescript",
-  "version": "1.5.0",
+  "version": "2.0.0",
   "license": "MIT",
   "exports": "./src/index.ts"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "func-typescript",
-  "version": "1.5.0",
+  "version": "2.0.0",
   "description": "A functional programming library for TypeScript, offering immutable data structures, expressive pattern matching, and powerful monadic types for safer and more concise code.",
   "main": "dist/index.js",
   "scripts": {

--- a/src/lib/Try.ts
+++ b/src/lib/Try.ts
@@ -112,7 +112,9 @@ export class Try<T> {
      * @param {...Array<Try<T[number]>>} args An array where the first elements are `Try` instances, followed by a function.
      * @returns {Try<R>} A `Try` instance containing either the function's result or the first failure encountered.
      */
-    static combine<T extends any[], R>(...args: [...{ [K in keyof T]: Try<T[K]> }, (...values: T) => R | Promise<R>]): Try<R> {
+    static combine<T extends any[], R>(...args: [...{ [K in keyof T]: Try<T[K]> }, (...values: T) => R | Promise<R>]): Try<R>;
+    static combine<T extends any[], R>(...args: [...{ [K in keyof T]: Try<T[K]> }, (...values: T) => R | Promise<R>, boolean]): Try<R>;
+    static combine<T extends any[], R>(...args: any[]): Try<R> {
         // @ts-ignore
         return new Try([()=> combine(...args)]);
     }

--- a/src/lib/Try.ts
+++ b/src/lib/Try.ts
@@ -128,8 +128,8 @@ export class Try<T> {
      * @param { [K in keyof T]: Try<T[K]> } tries An array where the first elements are `Try` instances.
      * @returns {Try<T>} A `Try` instance containing the values of the `Try` instances.
      */
-    static sequence<T extends readonly unknown[]>(tries: { [K in keyof T]: Try<T[K]> }): Try<T> {
-        return new Try([()=> sequence(tries)]);
+    static sequence<T extends readonly unknown[]>(tries: { [K in keyof T]: Try<T[K]> }, parallel = true): Try<T> {
+        return new Try([()=> sequence(tries, parallel)]);
     }
 
 

--- a/src/lib/functions/try/initializers/sequence.ts
+++ b/src/lib/functions/try/initializers/sequence.ts
@@ -4,19 +4,22 @@ import {runInTry} from "../helpers";
 
 
 
-export async function sequence<T extends readonly unknown[]>(tries: { [K in keyof T]: Try<T[K]> }): Promise<Result>{
+export async function sequence<T extends readonly unknown[]>(tries: { [K in keyof T]: Try<T[K]> }, parallel = false): Promise<Result>{
     const result = new Result();
-    const values: unknown[] = [];
+    let values: unknown[] = [];
 
-    for(const v of tries){
-        const success = await runInTry(async ()=>{
-            values.push(await v.get());
-        }, result);
+    const success = await runInTry(async () => {
+        if(parallel){
+            values =  await Promise.all(tries.map( values => values.get()))
+        }else{
+            for(const v of tries){
+                values.push(await v.get());
+            }
+        }
+    }, result)
 
-        if(!success)
-            return result;
-
-    }
+    if(!success)
+        return result;
 
     //@ts-ignore
     return result.setValue(values);

--- a/src/test/Try.test.ts
+++ b/src/test/Try.test.ts
@@ -505,7 +505,7 @@ describe("Try", () => {
 
     describe("Try.combine", () => {
 
-      test("combine should run all Try instances and pass the results to the provided function", async () => {
+      test("combine should resolve all Try instances sequentially and pass the results to the provided function", async () => {
           const r = Try.success(2);
           const r2 = Try.success(3);
           const r3 = Try.of(() => {
@@ -516,14 +516,14 @@ describe("Try", () => {
 
           const f = (a: number, b: number, c: string) => a + b + c;
 
-          const r4 = Try.combine(r, r2, r3, f);
+          const r4 = Try.combine(r, r2, r3, f, false);
 
           await expect(r4.get()).resolves.toBe("53");
           expect(r4.isSuccess()).toBe(true);
 
       });
 
-      test("combine should run all Try instances and results in Failure for the first instance that is a Failure", async () => {
+      test("combine should resolve all Try instances sequentially and results in Failure for the first instance that is a Failure", async () => {
           const r = Try.success(2);
           const r2 = Try.success(3);
           const r3 = Try.of(() => {
@@ -534,12 +534,68 @@ describe("Try", () => {
 
           const f = (a: number, b: number, c: string) => a + b + c;
 
-          const r4 = Try.combine(r, r2, r3, f);
+          const r4 = Try.combine(r, r2, r3, f, false);
 
           await expect(r4.get()).rejects.toThrow("Random error");
           expect(r4.isFailure()).toBe(true);
 
       });
+
+      test("combine should resolve all Try instances in parallel and pass the results to the provided function", async () => {
+        const r = Try.success(3).map(async v => {
+            await new Promise(resolve => setTimeout(resolve, 1000 * v));
+            return v;
+        });
+        const r2 = Try.success(4).map(async v => {
+            await new Promise(resolve => setTimeout(resolve, 1000  * v));
+            return v;
+        });
+        const r3 = Try.of(() => {
+            if(0.6 > 0.5) return "3";
+            throw new Error("Random error");
+        });
+
+
+        const f = (a: number, b: number, c: string) => a + b + c;
+
+        const r4 = Try.combine(r, r2, r3, f, true);
+
+        const start = performance.now();
+        await expect(r4.get()).resolves.toBe("73");
+        expect(r4.isSuccess()).toBe(true);
+        const timeTaken = (performance.now() - start) / 1000;
+        expect(timeTaken).toBeLessThan(5); //The maximum amount of time it should take is 5 seconds, because the longest running task is 4 seconds. The other 1 second is for the overhead of the test.
+
+      });
+
+      test("combine should resolve all Try instance in parallel and results in Failure for the first instance that is a Failure", async () => {
+        const r = Try.success(4).map(async v => {
+            await new Promise(resolve => setTimeout(resolve, 1000 * v));
+            return v;
+        });
+        const r2 = Try.success(3).map(async v => {
+            await new Promise(resolve => setTimeout(resolve, 1000  * v));
+            return v;
+        });
+        const r3 = Try.of(async () => {
+            if(0.3 > 0.5) await new Promise(resolve => setTimeout(resolve, 1000  * 2));
+            throw new Error("Random error 2");
+        });
+
+
+        const f = (a: number, b: number, c: string) => a + b + c;
+
+        const r4 = Try.combine(r, r2, r3, f);
+
+        const start = performance.now();
+        await expect(r4.get()).rejects.toThrow("Random error 2");
+        expect(r4.isFailure()).toBe(true);
+        const timeTaken = (performance.now() - start) / 1000;
+        expect(timeTaken).toBeLessThan(3); //The maximum amount of time it should take is 3 seconds, because the longest running task until the error is thrown is 2 seconds. The other 1 second is for the overhead of the test.
+
+    });
+
+
     });
 
     describe("Try.sequence", () => {


### PR DESCRIPTION
### Summary
Added optional parallel execution support to both `Try.combine` and `Try.sequence` methods, allowing developers to control whether Try instances are executed in parallel or sequentially.

### Changes Made
- **Added parallel parameter to `Try.combine`**: 
  - New optional boolean parameter as the last argument
  - Defaults to `true` (parallel execution)
  - Allows explicit control over execution order
- **Updated `Try.sequence` default behavior**:
  - Changed default from sequential to parallel execution
  - Maintains backward compatibility with explicit `parallel` parameter
- **Updated documentation**:
  - Added comprehensive examples showing parallel vs sequential usage
  - Clarified default behaviors for both methods
  - Fixed various documentation errors and inconsistencies

### Technical Details
- `Try.combine` now accepts: `(...tries, function, parallel?: boolean)`
- `Try.sequence` now defaults to parallel execution (`parallel = true`)
-  **This is a breaking change because the default behavior is execution in parallel**

### Benefits
- Improved performance for independent Try operations through parallel execution
- Explicit control over execution order when needed
- Better developer experience with clear documentation and examples